### PR TITLE
Fixed missing stack traces after deserialization

### DIFF
--- a/src/main/java/com/uber/cadence/internal/worker/ActivityExecutionException.java
+++ b/src/main/java/com/uber/cadence/internal/worker/ActivityExecutionException.java
@@ -41,8 +41,8 @@ class ActivityExecutionException extends RuntimeException {
      * @param reason  value of reason field
      * @param details application specific failure details
      */
-    ActivityExecutionException(String reason, byte[] details) {
-        super(reason);
+    ActivityExecutionException(String reason, byte[] details, Throwable cause) {
+        super(reason, cause);
         this.details = details;
     }
 

--- a/src/main/java/com/uber/cadence/internal/worker/POJOActivityImplementationFactory.java
+++ b/src/main/java/com/uber/cadence/internal/worker/POJOActivityImplementationFactory.java
@@ -69,7 +69,7 @@ class POJOActivityImplementationFactory implements ActivityImplementationFactory
         if (e instanceof CancellationException) {
             throw (CancellationException) e;
         }
-        return new ActivityExecutionException(e.getClass().getName(), dataConverter.toData(e));
+        return new ActivityExecutionException(e.getClass().getName(), dataConverter.toData(e), e);
     }
 
     @Override

--- a/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
+++ b/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
@@ -464,7 +464,9 @@ public class WorkflowTest {
             } catch (RuntimeException e) {
                 assertTrue(e.getMessage().contains("::throwNPE"));
                 assertNotNull(e.getCause() instanceof ActivityFailureException);
+                assertTrue(e.getStackTrace().length > 0);
                 assertNotNull(e.getCause().getCause() instanceof NullPointerException);
+                assertTrue(e.getCause().getStackTrace().length > 0);
                 assertEquals("simulated NPE", e.getCause().getCause().getMessage());
                 throw e;
             }
@@ -491,11 +493,14 @@ public class WorkflowTest {
             client.execute();
             fail("Unreachable");
         } catch (WorkflowFailureException e) {
-            e.printStackTrace();
             assertTrue(e.getMessage().contains("::throwNPE"));
+            assertTrue(e.getStackTrace().length > 0);
             assertNotNull(e.getCause().getCause() instanceof ActivityFailureException);
+            assertTrue(e.getCause().getStackTrace().length > 0);
             assertNotNull(e.getCause() instanceof WorkflowFailureException);
+            assertTrue(e.getCause().getCause().getStackTrace().length > 0);
             assertNotNull(e.getCause().getCause().getCause() instanceof NullPointerException);
+            assertTrue(e.getCause().getCause().getCause().getStackTrace().length > 0);
             assertEquals("simulated NPE", e.getCause().getCause().getCause().getMessage());
         }
     }


### PR DESCRIPTION
Throwable.setStackTrace has nasty "feature". If stackTace variable is null then it is "immutable" which means setStackTrace *silently* ignores the new stack :(.

This change work around it. For details see the comment in the JsonDataConverter.