### PR TITLE
Removed WorkflowThread from public API. WorkflowContext in callbacks

### DIFF
--- a/src/main/java/com/uber/cadence/internal/dispatcher/ActivityInvocationHandler.java
+++ b/src/main/java/com/uber/cadence/internal/dispatcher/ActivityInvocationHandler.java
@@ -61,7 +61,7 @@ class ActivityInvocationHandler implements InvocationHandler {
         } else {
             activityName = activityMethod.name();
         }
-        SyncDecisionContext decisionContext = WorkflowThreadInternal.currentThreadInternal().getDecisionContext();
+        SyncDecisionContext decisionContext = DeterministicRunnerImpl.currentThreadInternal().getDecisionContext();
         Promise<?> result = decisionContext.executeActivity(activityName, options, args, method.getReturnType());
         if (AsyncInternal.isAsync()) {
             AsyncInternal.setAsyncResult(result);

--- a/src/main/java/com/uber/cadence/internal/dispatcher/CallbackCoroutine.java
+++ b/src/main/java/com/uber/cadence/internal/dispatcher/CallbackCoroutine.java
@@ -21,6 +21,7 @@ import com.uber.cadence.workflow.Functions;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.function.Supplier;
 
 class CallbackCoroutine implements DeterministicRunnerCoroutine {
 
@@ -156,5 +157,15 @@ class CallbackCoroutine implements DeterministicRunnerCoroutine {
 
     @Override
     public void addStackTrace(StringBuilder result) {
+    }
+
+    @Override
+    public void yieldImpl(String reason, Supplier<Boolean> unblockCondition) throws DestroyWorkflowThreadError {
+        throw new IllegalStateException("Blocking calls are not allowed in callback threads");
+    }
+
+    @Override
+    public boolean yieldImpl(long timeoutMillis, String reason, Supplier<Boolean> unblockCondition) throws DestroyWorkflowThreadError {
+        throw new IllegalStateException("Blocking calls are not allowed in callback threads");
     }
 }

--- a/src/main/java/com/uber/cadence/internal/dispatcher/CallbackCoroutine.java
+++ b/src/main/java/com/uber/cadence/internal/dispatcher/CallbackCoroutine.java
@@ -25,6 +25,7 @@ import java.util.function.Supplier;
 
 class CallbackCoroutine implements DeterministicRunnerCoroutine {
 
+
     /**
      * Runnable passed to the thread that wraps a runnable passed to the WorkflowThreadImpl constructor.
      */
@@ -47,11 +48,13 @@ class CallbackCoroutine implements DeterministicRunnerCoroutine {
             thread = Thread.currentThread();
             originalName = thread.getName();
             thread.setName(name);
+            DeterministicRunnerImpl.setCurrentThreadInternal(CallbackCoroutine.this);
             try {
                 result = r.apply();
             } catch (Throwable e) {
                 unhandledException = e;
             } finally {
+                DeterministicRunnerImpl.setCurrentThreadInternal(null);
                 thread.setName(originalName);
                 thread = null;
             }
@@ -70,7 +73,7 @@ class CallbackCoroutine implements DeterministicRunnerCoroutine {
 
         boolean getResult() {
             if (result == null) {
-                throw new IllegalStateException("Result is not ready");
+                throw new IllegalStateException("Result is not ready", unhandledException);
             }
             return result;
         }
@@ -79,22 +82,17 @@ class CallbackCoroutine implements DeterministicRunnerCoroutine {
     private final ExecutorService threadPool;
     private final DeterministicRunnerImpl runner;
     private final RunnableWrapper task;
+    private final CancellationScopeImpl cancellationScope;
     private Thread thread;
     private Throwable unhandledException;
     private boolean stopped;
 
-
     /**
-     * If not 0 then thread is blocked on a sleep (or on an operation with a timeout).
-     * The value is the time in milliseconds (as in currentTimeMillis()) when thread will continue.
-     * Note that thread still has to be called for evaluation as other threads might interrupt the blocking call.
+     * @param coroutineFunction        returns false if no progress was made.
+     * @param ignoreParentCancellation
      */
-    private long blockedUntil;
-
-    /**
-     * @param coroutineFunction returns false if no progress was made.
-     */
-    public CallbackCoroutine(ExecutorService threadPool, DeterministicRunnerImpl runner, String name, Functions.Func<Boolean> coroutineFunction) {
+    public CallbackCoroutine(ExecutorService threadPool, DeterministicRunnerImpl runner, String name,
+                             Functions.Func<Boolean> coroutineFunction, boolean ignoreParentCancellation, CancellationScopeImpl parent) {
         this.threadPool = threadPool;
         this.runner = runner;
         // TODO: Use thread pool instead of creating new threads.
@@ -102,6 +100,8 @@ class CallbackCoroutine implements DeterministicRunnerCoroutine {
             name = "workflow-callbacks-" + super.hashCode();
         }
         this.task = new RunnableWrapper(name, coroutineFunction);
+        cancellationScope = new CancellationScopeImpl(ignoreParentCancellation, task, parent);
+
     }
 
     public DeterministicRunnerImpl getRunner() {
@@ -114,19 +114,15 @@ class CallbackCoroutine implements DeterministicRunnerCoroutine {
 
     @Override
     public long getBlockedUntil() {
-        return blockedUntil;
+        return 0;
     }
 
-//    public void setBlockedUntil(long blockedUntil) {
-//        this.blockedUntil = blockedUntil;
-//    }
-//
     /**
      * @return true if coroutine made some progress.
      */
     @Override
     public boolean runUntilBlocked() {
-        Future<?> taskFuture = threadPool.submit(task);
+        Future<?> taskFuture = threadPool.submit(cancellationScope::run);
         try {
             taskFuture.get();
         } catch (InterruptedException e) {

--- a/src/main/java/com/uber/cadence/internal/dispatcher/CancellationScopeImpl.java
+++ b/src/main/java/com/uber/cadence/internal/dispatcher/CancellationScopeImpl.java
@@ -124,16 +124,6 @@ class CancellationScopeImpl implements CancellationScope {
     }
 
     @Override
-    public boolean resetCanceled() {
-        boolean result = cancelRequested;
-        cancelRequested = false;
-        for (CancellationScopeImpl child : children) {
-            child.resetCanceled();
-        }
-        return result;
-    }
-
-    @Override
     public boolean isCancelRequested() {
         return cancelRequested;
     }

--- a/src/main/java/com/uber/cadence/internal/dispatcher/CancellationScopeImpl.java
+++ b/src/main/java/com/uber/cadence/internal/dispatcher/CancellationScopeImpl.java
@@ -61,9 +61,13 @@ class CancellationScopeImpl implements CancellationScope {
     private String reason;
 
     CancellationScopeImpl(boolean ignoreParentCancellation, Runnable runnable) {
+        this(ignoreParentCancellation, runnable, current());
+    }
+
+    CancellationScopeImpl(boolean ignoreParentCancellation, Runnable runnable, CancellationScopeImpl parent) {
         this.ignoreParentCancellation = ignoreParentCancellation;
         this.runnable = runnable;
-        setParent(current());
+        setParent(parent);
     }
 
     private void setParent(CancellationScopeImpl parent) {

--- a/src/main/java/com/uber/cadence/internal/dispatcher/CompletablePromiseImpl.java
+++ b/src/main/java/com/uber/cadence/internal/dispatcher/CompletablePromiseImpl.java
@@ -55,7 +55,7 @@ class CompletablePromiseImpl<V> implements CompletablePromise<V> {
     }
 
     CompletablePromiseImpl() {
-        runner = WorkflowThreadInternal.currentThreadInternal().getRunner();
+        runner = DeterministicRunnerImpl.currentThreadInternal().getRunner();
     }
 
     @Override

--- a/src/main/java/com/uber/cadence/internal/dispatcher/DeterministicRunner.java
+++ b/src/main/java/com/uber/cadence/internal/dispatcher/DeterministicRunner.java
@@ -18,7 +18,6 @@ package com.uber.cadence.internal.dispatcher;
 
 import com.uber.cadence.workflow.CancellationScope;
 import com.uber.cadence.workflow.Functions;
-import com.uber.cadence.workflow.WorkflowThread;
 
 import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;

--- a/src/main/java/com/uber/cadence/internal/dispatcher/DeterministicRunnerCoroutine.java
+++ b/src/main/java/com/uber/cadence/internal/dispatcher/DeterministicRunnerCoroutine.java
@@ -16,7 +16,13 @@
  */
 package com.uber.cadence.internal.dispatcher;
 
+import java.util.function.Supplier;
+
 interface DeterministicRunnerCoroutine {
+
+    DeterministicRunnerImpl getRunner();
+
+    SyncDecisionContext getDecisionContext();
 
     long getBlockedUntil();
 
@@ -29,4 +35,8 @@ interface DeterministicRunnerCoroutine {
     void stop();
 
     void addStackTrace(StringBuilder result);
+
+    void yieldImpl(String reason, Supplier<Boolean> unblockCondition) throws DestroyWorkflowThreadError;
+
+    boolean yieldImpl(long timeoutMillis, String reason, Supplier<Boolean> unblockCondition) throws DestroyWorkflowThreadError;
 }

--- a/src/main/java/com/uber/cadence/internal/dispatcher/DeterministicRunnerImpl.java
+++ b/src/main/java/com/uber/cadence/internal/dispatcher/DeterministicRunnerImpl.java
@@ -18,7 +18,6 @@ package com.uber.cadence.internal.dispatcher;
 
 import com.uber.cadence.workflow.Functions;
 import com.uber.cadence.workflow.Promise;
-import com.uber.cadence.workflow.WorkflowThread;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 

--- a/src/main/java/com/uber/cadence/internal/dispatcher/WorkflowInternal.java
+++ b/src/main/java/com/uber/cadence/internal/dispatcher/WorkflowInternal.java
@@ -184,7 +184,7 @@ public final class WorkflowInternal {
         return result;
     }
 
-    public static CancellationScope currentCancellationScope() {
+    public static CancellationScopeImpl currentCancellationScope() {
         return CancellationScopeImpl.current();
     }
 

--- a/src/main/java/com/uber/cadence/internal/dispatcher/WorkflowInternal.java
+++ b/src/main/java/com/uber/cadence/internal/dispatcher/WorkflowInternal.java
@@ -89,7 +89,7 @@ public final class WorkflowInternal {
      * Should be used to get current time instead of {@link System#currentTimeMillis()}
      */
     public static long currentTimeMillis() {
-        return WorkflowThreadInternal.currentThreadInternal().getRunner().currentTimeMillis();
+        return DeterministicRunnerImpl.currentThreadInternal().getRunner().currentTimeMillis();
     }
 
     /**
@@ -147,11 +147,7 @@ public final class WorkflowInternal {
     }
 
     private static SyncDecisionContext getDecisionContext() {
-        return WorkflowThreadInternal.currentThreadInternal().getDecisionContext();
-    }
-
-    public static DeterministicRunnerCoroutine currentThread() {
-        return WorkflowThreadInternal.currentThreadInternal();
+        return DeterministicRunnerImpl.currentThreadInternal().getDecisionContext();
     }
 
     public static void yield(String reason, Supplier<Boolean> unblockCondition) throws DestroyWorkflowThreadError {

--- a/src/main/java/com/uber/cadence/internal/dispatcher/WorkflowInternal.java
+++ b/src/main/java/com/uber/cadence/internal/dispatcher/WorkflowInternal.java
@@ -28,7 +28,6 @@ import com.uber.cadence.workflow.Promise;
 import com.uber.cadence.workflow.QueryMethod;
 import com.uber.cadence.workflow.WorkflowContext;
 import com.uber.cadence.workflow.WorkflowQueue;
-import com.uber.cadence.workflow.WorkflowThread;
 
 import java.lang.reflect.Proxy;
 import java.time.Duration;
@@ -151,12 +150,12 @@ public final class WorkflowInternal {
         return WorkflowThreadInternal.currentThreadInternal().getDecisionContext();
     }
 
-    public static WorkflowThread currentThread() {
+    public static DeterministicRunnerCoroutine currentThread() {
         return WorkflowThreadInternal.currentThreadInternal();
     }
 
-    public static boolean currentThreadResetCanceled() {
-        return WorkflowThreadInternal.currentThreadInternal().resetCanceled();
+    public static void yield(String reason, Supplier<Boolean> unblockCondition) throws DestroyWorkflowThreadError {
+        WorkflowThreadInternal.yield(reason, unblockCondition);
     }
 
     public static boolean yield(long timeoutMillis, String reason, Supplier<Boolean> unblockCondition) throws DestroyWorkflowThreadError {

--- a/src/main/java/com/uber/cadence/internal/dispatcher/WorkflowThread.java
+++ b/src/main/java/com/uber/cadence/internal/dispatcher/WorkflowThread.java
@@ -14,13 +14,13 @@
  *  express or implied. See the License for the specific language governing
  *  permissions and limitations under the License.
  */
-package com.uber.cadence.workflow;
+package com.uber.cadence.internal.dispatcher;
 
-import com.uber.cadence.internal.dispatcher.WorkflowInternal;
+import com.uber.cadence.workflow.CancellationScope;
 
 import java.time.Duration;
 
-public interface WorkflowThread extends CancellationScope {
+interface WorkflowThread extends CancellationScope {
 
     void start();
 
@@ -35,21 +35,6 @@ public interface WorkflowThread extends CancellationScope {
     String getName();
 
     long getId();
-
-    static WorkflowThread currentThread() {
-        return WorkflowInternal.currentThread();
-    }
-
-    static void sleep(Duration duration) {
-        sleep(duration.toMillis());
-    }
-
-    static void sleep(long millis) {
-        WorkflowInternal.yield(millis, "sleep", () -> {
-            CancellationScope.throwCancelled();
-            return false;
-        });
-    }
 
     String getStackTrace();
 }

--- a/src/main/java/com/uber/cadence/internal/dispatcher/WorkflowThreadContext.java
+++ b/src/main/java/com/uber/cadence/internal/dispatcher/WorkflowThreadContext.java
@@ -111,7 +111,7 @@ class WorkflowThreadContext {
             if (function == null) {
                 throw new IllegalArgumentException("null function");
             }
-            if (status != Status.YIELDED) {
+            if (status != Status.YIELDED && status != Status.RUNNING) {
                 throw new IllegalStateException("Not in yielded status: " + status);
             }
             if (evaluationFunction != null) {

--- a/src/main/java/com/uber/cadence/internal/worker/AsyncWorkflow.java
+++ b/src/main/java/com/uber/cadence/internal/worker/AsyncWorkflow.java
@@ -19,9 +19,6 @@ package com.uber.cadence.internal.worker;
 import com.uber.cadence.HistoryEvent;
 import com.uber.cadence.WorkflowQuery;
 import com.uber.cadence.internal.AsyncDecisionContext;
-import com.uber.cadence.workflow.WorkflowThread;
-
-import java.util.concurrent.CancellationException;
 
 public interface AsyncWorkflow {
 
@@ -49,7 +46,7 @@ public interface AsyncWorkflow {
 
     /**
      * @return time at which workflow can make progress.
-     * For example when {@link WorkflowThread#sleep(long)} expires.
+     * For example when {@link com.uber.cadence.workflow.Workflow#sleep(long)} expires.
      */
     long getNextWakeUpTime();
 

--- a/src/main/java/com/uber/cadence/workflow/CancellationScope.java
+++ b/src/main/java/com/uber/cadence/workflow/CancellationScope.java
@@ -42,12 +42,6 @@ public interface CancellationScope {
     String getCancellationReason();
 
     /**
-     * Changes canceled flag in the current scope and all its connected children.
-     * @return true if scope had {@link #isCancelRequested()} == true before this call.
-     */
-    boolean resetCanceled();
-
-    /**
      * Is scope was asked to cancel through {@link #cancel()} or by a parent scope.
      * @return
      */

--- a/src/main/java/com/uber/cadence/workflow/Workflow.java
+++ b/src/main/java/com/uber/cadence/workflow/Workflow.java
@@ -118,6 +118,17 @@ public final class Workflow {
         return WorkflowInternal.currentTimeMillis();
     }
 
+    public static void sleep(Duration duration) {
+        sleep(duration.toMillis());
+    }
+
+    public static void sleep(long millis) {
+        WorkflowInternal.yield(millis, "sleep", () -> {
+            CancellationScope.throwCancelled();
+            return false;
+        });
+    }
+
     /**
      * Creates client stub that can be used to continue this workflow as new generation.
      *

--- a/src/test/java/com/uber/cadence/internal/dispatcher/DeterministicRunnerTest.java
+++ b/src/test/java/com/uber/cadence/internal/dispatcher/DeterministicRunnerTest.java
@@ -19,9 +19,9 @@ package com.uber.cadence.internal.dispatcher;
 import com.uber.cadence.workflow.Async;
 import com.uber.cadence.workflow.CancellationScope;
 import com.uber.cadence.workflow.CompletablePromise;
+import com.uber.cadence.workflow.Functions;
 import com.uber.cadence.workflow.Promise;
 import com.uber.cadence.workflow.Workflow;
-import com.uber.cadence.workflow.WorkflowThread;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,6 +34,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.junit.Assert.*;
 
@@ -68,11 +69,11 @@ public class DeterministicRunnerTest {
     public void testYield() throws Throwable {
         DeterministicRunner d = new DeterministicRunnerImpl(() -> {
             status = "started";
-            WorkflowThreadInternal.yield("reason1",
+            WorkflowInternal.yield("reason1",
                     () -> unblock1
             );
             status = "after1";
-            WorkflowThreadInternal.yield("reason2",
+            WorkflowInternal.yield("reason2",
                     () -> unblock2
             );
             status = "done";
@@ -101,9 +102,9 @@ public class DeterministicRunnerTest {
                 () -> currentTime, // clock override
                 () -> {
                     status = "started";
-                    WorkflowThread.sleep(60000);
+                    Workflow.sleep(60000);
                     status = "afterSleep1";
-                    WorkflowThread.sleep(60000);
+                    Workflow.sleep(60000);
                     status = "done";
                 });
         currentTime = 1000;
@@ -135,7 +136,7 @@ public class DeterministicRunnerTest {
     public void testRootFailure() throws Throwable {
         DeterministicRunner d = new DeterministicRunnerImpl(() -> {
             status = "started";
-            WorkflowThreadInternal.yield("reason1",
+            WorkflowInternal.yield("reason1",
                     () -> unblock1
             );
             throw new RuntimeException("simulated");
@@ -157,12 +158,12 @@ public class DeterministicRunnerTest {
     public void testDispatcherStop() throws Throwable {
         DeterministicRunner d = new DeterministicRunnerImpl(() -> {
             status = "started";
-            WorkflowThreadInternal.yield("reason1",
+            WorkflowInternal.yield("reason1",
                     () -> unblock1
             );
             status = "after1";
             try {
-                WorkflowThreadInternal.yield("reason2",
+                WorkflowInternal.yield("reason2",
                         () -> unblock2
                 );
             } catch (DestroyWorkflowThreadError e) {
@@ -187,26 +188,24 @@ public class DeterministicRunnerTest {
     public void testDispatcherExit() throws Throwable {
         DeterministicRunner d = new DeterministicRunnerImpl(() -> {
             trace.add("root started");
-            WorkflowThread thread1 = WorkflowInternal.newThread(false, () -> {
+            Promise<Void> thread1 = Async.invoke(() -> {
                 trace.add("child1 started");
-                WorkflowThreadInternal.yield("reason1",
+                WorkflowInternal.yield("reason1",
                         () -> unblock1
                 );
                 trace.add("child1 done");
             });
-            WorkflowThread thread2 = WorkflowInternal.newThread(false, () -> {
+            Promise<Void> thread2 = Async.invoke(() -> {
                 trace.add("child2 started");
-                WorkflowThreadInternal.yield("reason2",
+                WorkflowInternal.yield("reason2",
                         () -> unblock2
                 );
                 trace.add("child2 exiting");
                 WorkflowThreadInternal.exit("exitValue");
                 trace.add("child2 done");
             });
-            thread1.start();
-            thread2.start();
-            thread1.join();
-            thread2.join();
+            thread1.get();
+            thread2.get();
             trace.add("root done");
         });
         d.runUntilAllBlocked();
@@ -230,11 +229,11 @@ public class DeterministicRunnerTest {
         trace.add("init");
         DeterministicRunner d = new DeterministicRunnerImpl(() -> {
             trace.add("root started");
-            WorkflowThreadInternal.yield("reason1",
+            WorkflowInternal.yield("reason1",
                     () -> CancellationScope.current().isCancelRequested()
             );
             trace.add("second yield: " + CancellationScope.current().getCancellationReason());
-            WorkflowThreadInternal.yield("reason1",
+            WorkflowInternal.yield("reason1",
                     () -> CancellationScope.current().isCancelRequested()
             );
             trace.add("root done");
@@ -328,7 +327,7 @@ public class DeterministicRunnerTest {
     private Promise<Void> newTimer(int milliseconds) {
         return Async.invoke(() -> {
             try {
-                WorkflowThread.sleep(milliseconds);
+                Workflow.sleep(milliseconds);
                 trace.add("timer fired");
             } catch (CancellationException e) {
                 trace.add("timer cancelled");
@@ -347,7 +346,7 @@ public class DeterministicRunnerTest {
                 Async.invoke(() -> {
                     trace.add("thread started");
                     Promise<String> cancellation = CancellationScope.current().getCancellationRequest();
-                    WorkflowThreadInternal.yield("reason1",
+                    WorkflowInternal.yield("reason1",
                             () -> CancellationScope.current().isCancelRequested()
                     );
                     trace.add("thread done: " + cancellation.get());
@@ -382,7 +381,7 @@ public class DeterministicRunnerTest {
             Workflow.newDetachedCancellationScope(() -> {
                 Async.invoke(() -> {
                     trace.add("thread started");
-                    WorkflowThreadInternal.yield("reason1",
+                    WorkflowInternal.yield("reason1",
                             () -> unblock1 || CancellationScope.current().isCancelRequested()
                     );
                     if (CancellationScope.current().isCancelRequested()) {
@@ -427,19 +426,18 @@ public class DeterministicRunnerTest {
     @Test
     public void testChild() throws Throwable {
         DeterministicRunner d = new DeterministicRunnerImpl(() -> {
-            WorkflowThread thread = WorkflowInternal.newThread(false, () -> {
+            Promise<Void> async = Async.invoke(() -> {
                 status = "started";
-                WorkflowThreadInternal.yield("reason1",
+                WorkflowInternal.yield("reason1",
                         () -> unblock1
                 );
                 status = "after1";
-                WorkflowThreadInternal.yield("reason2",
+                WorkflowInternal.yield("reason2",
                         () -> unblock2
                 );
                 status = "done";
             });
-            thread.start();
-            thread.join();
+            async.get();
         });
         assertEquals("initial", status);
         d.runUntilAllBlocked();
@@ -466,15 +464,18 @@ public class DeterministicRunnerTest {
                 () -> {
                     trace.add("root started");
 
-                    WorkflowThread thread = WorkflowInternal.newThread(false, () -> {
+                    Promise<Void> thread = Async.invoke(() -> {
                         trace.add("child started");
-                        WorkflowThreadInternal.yield("blockForever",
+                        WorkflowInternal.yield("blockForever",
                                 () -> false
                         );
                         trace.add("child done");
                     });
-                    thread.start();
-                    thread.join(60000);
+                    try {
+                        thread.get(60000, TimeUnit.MILLISECONDS);
+                    } catch (TimeoutException e) {
+                        trace.add("timeout exception");
+                    }
                     trace.add("root done");
                 });
         currentTime = 1000;
@@ -495,6 +496,7 @@ public class DeterministicRunnerTest {
         expected = new String[]{
                 "root started",
                 "child started",
+                "timeout exception",
                 "root done"
         };
         assertTrace(expected, trace);
@@ -507,7 +509,7 @@ public class DeterministicRunnerTest {
 
     private static final int CHILDREN = 10;
 
-    private class TestChildTreeRunnable implements Runnable {
+    private class TestChildTreeRunnable implements Functions.Proc {
         final int depth;
 
         private TestChildTreeRunnable(int depth) {
@@ -515,26 +517,25 @@ public class DeterministicRunnerTest {
         }
 
         @Override
-        public void run() {
+        public void apply() {
             trace.add("child " + depth + " started");
             if (depth >= CHILDREN) {
                 trace.add("child " + depth + " done");
                 return;
             }
-            WorkflowThread thread = WorkflowInternal.newThread(false,
+            Promise<Void> thread = Async.invoke(
                     new TestChildTreeRunnable(depth + 1));
-            thread.start();
-            WorkflowThreadInternal.yield("reason1",
+            WorkflowInternal.yield("reason1",
                     () -> unblock1
             );
-            thread.join();
+            thread.get();
             trace.add("child " + depth + " done");
         }
     }
 
     @Test
     public void testChildTree() throws Throwable {
-        DeterministicRunner d = new DeterministicRunnerImpl(new TestChildTreeRunnable(0));
+        DeterministicRunner d = new DeterministicRunnerImpl(new TestChildTreeRunnable(0)::apply);
         d.runUntilAllBlocked();
         unblock1 = true;
         d.runUntilAllBlocked();

--- a/src/test/java/com/uber/cadence/internal/dispatcher/DeterministicRunnerTest.java
+++ b/src/test/java/com/uber/cadence/internal/dispatcher/DeterministicRunnerTest.java
@@ -341,7 +341,7 @@ public class DeterministicRunnerTest {
         trace.add("init");
         DeterministicRunner d = new DeterministicRunnerImpl(() -> {
             trace.add("root started");
-            CompletablePromise<Object> threadDone = Workflow.newCompletablePromise();
+            CompletablePromise<String> threadDone = Workflow.newCompletablePromise();
             CancellationScope scope = Workflow.newCancellationScope(() -> {
                 Async.invoke(() -> {
                     trace.add("thread started");
@@ -349,8 +349,8 @@ public class DeterministicRunnerTest {
                     WorkflowInternal.yield("reason1",
                             () -> CancellationScope.current().isCancelRequested()
                     );
+                    threadDone.completeFrom(cancellation);
                     trace.add("thread done: " + cancellation.get());
-                    threadDone.complete(null);
                 });
             });
             trace.add("root before cancel");

--- a/src/test/java/com/uber/cadence/internal/dispatcher/WorkflowInternalQueueTest.java
+++ b/src/test/java/com/uber/cadence/internal/dispatcher/WorkflowInternalQueueTest.java
@@ -16,8 +16,8 @@
  */
 package com.uber.cadence.internal.dispatcher;
 
+import com.uber.cadence.workflow.Workflow;
 import com.uber.cadence.workflow.WorkflowQueue;
-import com.uber.cadence.workflow.WorkflowThread;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -81,7 +81,7 @@ public class WorkflowInternalQueueTest {
             WorkflowInternal.newThread(false, () -> {
                 try {
                     trace.add("thread1 begin");
-                    WorkflowThread.sleep(2000);
+                    Workflow.sleep(2000);
                     assertTrue(f.take());
                     trace.add("thread1 take1 success");
                     assertFalse(f.take());

--- a/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
+++ b/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
@@ -726,7 +726,7 @@ public class WorkflowTest {
             while (cause.getCause() != null) {
                 cause = cause.getCause();
             }
-            assertTrue(e.toString(), cause.getMessage().contains("Called from non workflow or workflow callback thread"));
+            assertTrue(e.toString(), cause.getMessage().contains("Blocking calls are not allowed in callback threads"));
         }
     }
 

--- a/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
+++ b/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
@@ -176,7 +176,7 @@ public class WorkflowTest {
             // In real workflows use
             // Async.invoke(activities::activityWithDelay, 1000, true)
             Promise<String> a1 = Async.invoke(() -> activities.activityWithDelay(1000, true));
-            WorkflowThread.sleep(2000);
+            Workflow.sleep(2000);
             return activities.activity2(a1.get(), 10);
         }
     }
@@ -263,7 +263,7 @@ public class WorkflowTest {
                 Workflow.newDetachedCancellationScope(() -> assertEquals("a1", testActivities.activity1("a1")));
             }
             try {
-                WorkflowThread.sleep(Duration.ofHours(1));
+                Workflow.sleep(Duration.ofHours(1));
             } catch (CancellationException e) {
                 Workflow.newDetachedCancellationScope(() -> assertEquals("a12", testActivities.activity2("a1", 2)));
             }

--- a/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
+++ b/src/test/java/com/uber/cadence/workflow/WorkflowTest.java
@@ -432,6 +432,12 @@ public class WorkflowTest {
             Promise<Void> timer2 = Workflow.newTimer(Duration.ofMillis(1300));
 
             long time = Workflow.currentTimeMillis();
+            timer1.thenApply((r) -> {
+                // Testing that timer can be created from a callback thread.
+                Workflow.newTimer(Duration.ofSeconds(10));
+                Workflow.currentTimeMillis(); // Testing that time is available here.
+                return r;
+            }).get();
             timer1.get();
             long slept = Workflow.currentTimeMillis() - time;
             // Also checks that rounding up to a second works.


### PR DESCRIPTION
After Async.invoke was introduced WorkflowThread is not necessary anymore.
Added support for creating timers and getting time in timer callbacks. Blocking in them still prohibited.